### PR TITLE
メッセージリスナーと新規登録後の編集画面拘束 & ホームとメッセージ画面の検索機能

### DIFF
--- a/src/components/atoms/NumberField.vue
+++ b/src/components/atoms/NumberField.vue
@@ -1,0 +1,53 @@
+<template>
+  <input type="number" :min="option.min" :step="option.step" :placeholder="label" v-model="innerValue" />
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+
+export default defineComponent({
+  name: "NumberField",
+  props: {
+    value: {
+      //入力される文字列
+      type: Number,
+      required: true,
+    },
+    id: Number,
+    label: {
+      //テキストフィールドに表示する文字列
+      type: String,
+      default: "",
+    },
+    option: {
+      //制限等の設定の情報
+      type: Object as PropType<{ min?: number; step?: number }>,
+      required: false,
+    },
+  },
+  computed: {
+    innerValue: {
+      get(): number | undefined {
+        return this.value;
+      },
+      set(value: number) {
+        this.$emit("change-value", Number(value), this.id);
+      },
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/color.scss";
+
+input[type="number"] {
+  font-size: 20px;
+  width: 100%;
+  height: 32px;
+  color: $-primary-800;
+  background-color: $-primary-100;
+  border: 2px solid $-primary-800;
+  outline: none;
+}
+</style>

--- a/src/components/atoms/SelectBox.vue
+++ b/src/components/atoms/SelectBox.vue
@@ -1,0 +1,50 @@
+<template>
+  <select v-model="innerValue">
+    <option v-for="(item, index) in data" :key="index" :value="item.id">
+      {{ item.label }}
+    </option>
+  </select>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+
+import { IselectBoxList } from "@/mixins/selectBoxList";
+
+export default defineComponent({
+  name: "SelectBox",
+  props: {
+    value: {
+      //選択されている値
+      type: Number,
+      required: true,
+    },
+    data: {
+      //選択肢のデータ配列
+      type: Array as PropType<IselectBoxList[]>,
+      required: true,
+    },
+  },
+  computed: {
+    innerValue: {
+      get(): number | undefined {
+        return this.value;
+      },
+      set(value: number) {
+        this.$emit("change-value", Number(value));
+      },
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/color.scss";
+
+select {
+  font-size: 20px;
+  width: 100%;
+  height: 32px;
+  color: $-primary-800;
+}
+</style>

--- a/src/components/atoms/UserIcon.vue
+++ b/src/components/atoms/UserIcon.vue
@@ -19,5 +19,7 @@ export default defineComponent({
 .icon {
   width: 100%;
   height: 100%;
+  border-radius: 50%;
+  background: silver; //テスト用
 }
 </style>

--- a/src/components/molecules/FormComponent.vue
+++ b/src/components/molecules/FormComponent.vue
@@ -5,6 +5,7 @@
       :is="form.formType"
       :value="form.value"
       :id="form.id"
+      :option="form.option"
       @change-value="changeValue"
     />
   </div>
@@ -15,13 +16,15 @@ import { defineComponent, PropType } from "vue";
 
 import TextField from "@/components/atoms/TextField.vue";
 import TextFieldOrange from "@/components/atoms/TextFieldOrange.vue";
+import NumberField from "@/components/atoms/NumberField.vue";
 import PassField from "@/components/atoms/PassField.vue";
 import TextArea from "@/components/atoms/TextArea.vue";
 
 export type PropFormType = {
   id: number;
   label: string;
-  value: string;
+  option?: { min?: number; step?: number };
+  value: string | number;
   formType: string;
 };
 
@@ -30,6 +33,7 @@ export default defineComponent({
   components: {
     TextField,
     TextFieldOrange,
+    NumberField,
     PassField,
     TextArea,
   },
@@ -40,7 +44,7 @@ export default defineComponent({
     },
   },
   methods: {
-    changeValue(value: String, key: Number) {
+    changeValue(value: string | number, key: number) {
       this.$emit("change-value", value, key);
     },
   },

--- a/src/components/molecules/MessageItem.vue
+++ b/src/components/molecules/MessageItem.vue
@@ -58,14 +58,14 @@ export default defineComponent({
   .user-icon {
     width: 44px;
     height: 44px;
-    background: $-primary-500;
+    background: $-primary-600;
     border-radius: 50%;
     margin: 2px 0px 0px 2px; //上下左右中央揃え用
   }
 
   .message-body {
     border-radius: 0px 22px 22px 22px;
-    border: 2px solid $-primary-500;
+    border: 2px solid $-primary-600;
     padding: 8px;
     white-space: pre-line; //\nがあると改行
   }

--- a/src/components/molecules/SearchForm.vue
+++ b/src/components/molecules/SearchForm.vue
@@ -1,35 +1,48 @@
 <template>
   <div class="search-form">
-    <TextFieldWhite
+    <component
+      :is="formData.formType"
       label=" 検索ボックス"
       :value="searchWord"
+      :option="formData.option"
       @change-value="changeValue"
     />
-    <CommonButton label="検索" />
+    <CommonButton label="検索" @click-event="searchMixer"/>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, PropType } from "vue";
 
 import TextFieldWhite from "@/components/atoms/TextFieldWhite.vue";
+import NumberField from "@/components/atoms/NumberField.vue";
 import CommonButton from "@/components/atoms/CommonButton.vue";
+
+import { IselectBoxList } from "@/mixins/selectBoxList";
 
 export default defineComponent({
   name: "SearchForm",
   components: {
     TextFieldWhite,
+    NumberField,
     CommonButton,
   },
   props: {
-    searchWord: {//検索ワード
-      type: String,
+    searchWord: { //検索ワード
+      type: [String, Number],
+      required: true,
+    },
+    formData: { //検索ボックスの種類
+      type: Object as PropType<IselectBoxList>,
       required: true,
     },
   },
   methods: {
-    changeValue(value: string, key: number) {
+    changeValue(value: string | number, key: number) { //検索ワードを文字列にして変更
       this.$emit("change-value", value);
+    },
+    searchMixer(): void {
+      this.$emit("search-mixer");
     },
   },
 });

--- a/src/components/molecules/UserTab.vue
+++ b/src/components/molecules/UserTab.vue
@@ -54,31 +54,32 @@ export default defineComponent({
   grid-template-columns: 52px 1fr;
   column-gap: 16px;
   margin: 16px 0px;
+  overflow: hidden;
   cursor: pointer;
   .icon {
     width: 52px;
     height: 52px;
-    background: $-primary-500;
+    background: $-primary-600;
     border-radius: 50%;
     margin: 2px 0px 0px 2px; //上下左右中央揃え用
   }
 
   .name {
     font-size: 32px;
-    color: $-primary-500;
+    color: $-primary-600;
     display: flex;
     justify-content: center;
     align-items: center;
-    border-left: 4px solid $-primary-500;
-    border-right: 4px solid $-primary-500;
+    border-left: 4px solid $-primary-600;
+    border-right: 4px solid $-primary-600;
   }
 
   &:hover {
-    background: $-primary-300;
+    background: $-primary-200;
   }
 }
 
 .selected {
-  background: $-primary-500;
+  background: $-primary-200;
 }
 </style>

--- a/src/components/organisms/EditForm.vue
+++ b/src/components/organisms/EditForm.vue
@@ -27,7 +27,7 @@ export default defineComponent({
     formData: Array as PropType<IformData[]>, //編集画面のデータ
   },
   methods: {
-    changeValue(value: String, key: Number) {
+    changeValue(value: string | number, key: number) {
       (this as any).$emit("change-value", value, key);
     },
   },

--- a/src/mixins/defaultProfileData.ts
+++ b/src/mixins/defaultProfileData.ts
@@ -14,18 +14,18 @@ export const DEFAULT_SINGER_DATA: IsingerData = { //歌い手のデータの初�
 }
 
 export interface ImixerData {
+    uid?: string;
     name: string;
     detail: string;
     twitter: string;
-    fee: string;
-    deadline: string;
-    [key: string]: string;
+    fee: number;
+    deadline: number;
 }
 
 export const DEFAULT_MIXER_DATA: ImixerData = { //Mixerのデータの初期値(後にiconキー追加)
     name: "お名前",
     detail: "よろしくお願いします。",
     twitter: "@",
-    fee: "",
-    deadline: "",
+    fee: 0,
+    deadline: 0,
 }

--- a/src/mixins/selectBoxList.ts
+++ b/src/mixins/selectBoxList.ts
@@ -1,0 +1,44 @@
+export interface IselectBoxList {
+    id: number;
+    label: string;
+    keyName: string;
+    option?: { min?: number; step?: number };
+    formType: string;
+}
+
+export const HOME_SEARCH_TYPE_LIST: IselectBoxList[] = [
+    {
+        id: 0,
+        label: "名前で検索",
+        keyName: "name",
+        formType: "TextFieldWhite",
+    },
+    {
+        id: 1,
+        label: "料金（円）の上限で検索",
+        keyName: "fee",
+        option: { min: 0, step: 100 },
+        formType: "NumberField",
+    },
+    {
+        id: 2,
+        label: "料金（円）の下限で検索",
+        keyName: "fee",
+        option: { min: 0, step: 100 },
+        formType: "NumberField",
+    },
+    {
+        id: 3,
+        label: "納期（日数）の上限で検索",
+        keyName: "deadline",
+        option: { min: 0 },
+        formType: "NumberField",
+    },
+    {
+        id: 4,
+        label: "納期（日数）の下限で検索",
+        keyName: "deadline",
+        option: { min: 0 },
+        formType: "NumberField",
+    },
+]

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import Message from '../views/Message.vue';
 import Edit from '../views/Edit.vue';
 import Profile from '../views/Profile.vue';
 import store from '../store';
+import { profileDataType } from '@/store/exchange/models';
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -62,8 +63,9 @@ router.beforeResolve((to, from, next) => {
   } else if (from.name === 'Edit' || from.name === undefined) { //編集画面から離れる時やURLを叩いてサイトを開いた時
     const selfProfile = store.state.exchange.selfProfileData;
     let hasEmpty: boolean = false; //プロフィール情報に空があるならtrue
-    for (let i in selfProfile) {
-      hasEmpty = selfProfile[i] === "" || hasEmpty ? true : false; //どれか一つでも値が空なら真偽値をtrueに
+    const profileItemList = Object.values(selfProfile); //プロフィールの値のリスト
+    for (let i in profileItemList) {
+      hasEmpty = profileItemList[i] === "" || hasEmpty ? true : false; //どれか一つでも値が空なら真偽値をtrueに
     }
 
     if (hasEmpty) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -33,7 +33,7 @@ const routes: Array<RouteRecordRaw> = [
     component: Edit,
     beforeEnter: (to, from, next) => { //ログアウト状態だと編集画面に飛べない処理
       if (!store.state.auth.singerState && !store.state.auth.mixerState) {
-        next('/')
+        next('/');
         alert("編集機能はログインしないと使用できません。");
         store.dispatch("common/closeAside"); //サイドバーを閉じる
         store.commit("common/setLogInLabel", "ログイン"); //新規登録かログインかを変更
@@ -53,6 +53,29 @@ const routes: Array<RouteRecordRaw> = [
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes
+});
+
+router.beforeResolve((to, from, next) => {
+  //グローバルなルートの変更時
+  if (to.name === 'Edit') { //編集画面に入るときはバリデート不必要
+    next();
+  } else if (from.name === 'Edit' || from.name === undefined) { //編集画面から離れる時やURLを叩いてサイトを開いた時
+    const selfProfile = store.state.exchange.selfProfileData;
+    let hasEmpty: boolean = false; //プロフィール情報に空があるならtrue
+    for (let i in selfProfile) {
+      hasEmpty = selfProfile[i] === "" || hasEmpty ? true : false; //どれか一つでも値が空なら真偽値をtrueに
+    }
+
+    if (hasEmpty) {
+      alert("すべての項目を埋めて、保存する必要があります");
+      store.dispatch("common/closeAside"); //サイドバーを閉じる
+      next('/edit'); //空白があるなら編集画面へ
+    } else {
+      next(); //空白がないならそのまま
+    }
+  } else {
+    next();
+  }
 });
 
 export default router;

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -9,6 +9,16 @@ export const actions: ActionTree<IcommonState, RootState> = {
   closeAside({ commit }): void {
     commit("setAsideState", false);
   },
+  changeSearchType({ commit, state }, payload: number): void { //検索モード変更の処理
+    commit("setSearchTypeId", payload); //検索モード変更
+
+    const searchWord = state.searchWord;
+    if (typeof searchWord === "string" && payload !== 0) { //対象が名前から名前以外になった場合
+      commit("setSearchWord", 0); //数字の初期化
+    } else if (typeof searchWord === "number" && payload === 0) {//対象が名前以外から名前になった場合
+      commit("setSearchWord", ""); //文字列に初期化
+    }
+  },
   error({ commit }, payload) {
     commit("setErrorMessage", payload);
   },

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -1,9 +1,15 @@
 export interface IcommonState {
-  isOpeningAside: boolean; //サイドバーが開いているときはtrue
+  isOpeningAside: boolean;
   logInLabel: string;
+
+  searchWord: string | number;
+  searchTypeId: number;
 }
 
 export class CommonState implements IcommonState {
-  isOpeningAside = false;
+  isOpeningAside = false; //サイドバーが開いているときはtrue
   logInLabel = "ログイン";
+
+  searchWord = ""; //検索ワード
+  searchTypeId = 0; //検索対象のID(0~4)
 }

--- a/src/store/common/mutations.ts
+++ b/src/store/common/mutations.ts
@@ -12,4 +12,10 @@ export const mutations: MutationTree<IcommonState> = {
   setLogInLabel(state: IcommonState, payload: string): void {
     state.logInLabel = payload;
   },
+  setSearchWord(state: IcommonState, payload: string | number): void {
+    state.searchWord = payload;
+  },
+  setSearchTypeId(state: IcommonState, payload: number): void {
+    state.searchTypeId = payload;
+  },
 };

--- a/src/store/exchange/models.ts
+++ b/src/store/exchange/models.ts
@@ -14,8 +14,8 @@ export type messageDataType = {
 }
 
 export interface IexchangeState {
-    selfProfileData: profileDataType | { [key: string]: string }; //キーはdefaultProfileと同じ
-    clientProfileData: profileDataType | { [key: string]: string }; //キーはdefaultProfileのキーとuid
+    selfProfileData: Partial<profileDataType>; //キーはdefaultProfileと同じ
+    clientProfileData: Partial<profileDataType>; //キーはdefaultProfileのキーとuid
 
     isShowingSinger: boolean;
     homeMixerList: profileDataType[];

--- a/src/store/exchange/models.ts
+++ b/src/store/exchange/models.ts
@@ -23,6 +23,8 @@ export interface IexchangeState {
     clientList: profileDataType[];
     selectedUid: string;
     messageList: messageDataType[];
+
+    unsubscribe: () => void;
 }
 
 export class ExchangeState implements IexchangeState {
@@ -35,4 +37,6 @@ export class ExchangeState implements IexchangeState {
     clientList = []; //チャットのやりとりをする相手のリスト
     selectedUid = ""; //開いているチャット相手のUID
     messageList = []; //選択した相手とのチャットデータのリスト
+
+    unsubscribe = () => {}; //メッセージのリスナー処理
 }

--- a/src/store/exchange/mutations.ts
+++ b/src/store/exchange/mutations.ts
@@ -27,4 +27,7 @@ export const mutations: MutationTree<IexchangeState> = {
   setMessageList(state: IexchangeState, payload: messageDataType[]): void { //チャット相手との会話データのリストの変更
     state.messageList = payload;
   },
+  setUnsubscribe(state: IexchangeState, payload: () => void): void { //チャット相手との会話データのリストの変更
+    state.unsubscribe = payload;
+  },
 };

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -122,7 +122,7 @@ export default defineComponent({
       ],
     };
   },
-  created() {
+  created() { //呼び出された直後
     this.setFormDataValue(); //初期はvuexの情報を表示
   },
   computed: {
@@ -174,15 +174,14 @@ export default defineComponent({
               "exchange/updateProfile",
               editFormData
             );
-            console.log(editFormData[0].value);
           }
-        }else{
+        } else {
           if (
             editFormData[0].value == "" ||
             editFormData[1].value == "" ||
             editFormData[2].value == "" ||
             editFormData[3].value == "" ||
-            editFormData[4].value == "" 
+            editFormData[4].value == ""
           ) {
             alert("全ての事項を記入してください。");
           } else {
@@ -190,7 +189,6 @@ export default defineComponent({
               "exchange/updateProfile",
               editFormData
             );
-            console.log(editFormData[0].value);
           }
         }
       } else {

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -99,15 +99,17 @@ export default defineComponent({
         },
         {
           id: 4,
-          label: "料金",
-          value: "",
-          formType: "TextArea",
+          label: "料金（円）",
+          option: { min: 0, step: 100 },
+          value: 0,
+          formType: "NumberField",
         },
         {
           id: 5,
-          label: "納期",
-          value: "",
-          formType: "TextArea",
+          label: "納期（日以内）",
+          option: { min: 0 },
+          value: 0,
+          formType: "NumberField",
         },
       ],
       whiteButtonsData: [
@@ -149,10 +151,10 @@ export default defineComponent({
         }
       }
     },
-    changeSingerValue(value: string, key: number): void {
+    changeSingerValue(value: string | number, key: number): void {
       this.singerFormData[key - 1].value = value;
     },
-    changeMixerValue(value: string, key: number): void {
+    changeMixerValue(value: string | number, key: number): void {
       this.mixerFormData[key - 1].value = value;
     },
     clickButton(id: number): void {
@@ -180,8 +182,8 @@ export default defineComponent({
             editFormData[0].value == "" ||
             editFormData[1].value == "" ||
             editFormData[2].value == "" ||
-            editFormData[3].value == "" ||
-            editFormData[4].value == ""
+            editFormData[3].value == NaN ||
+            editFormData[4].value == NaN
           ) {
             alert("全ての事項を記入してください。");
           } else {

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -112,7 +112,7 @@ export default defineComponent({
       ],
       whiteButtonsData: [
         {
-          label: "完了",
+          label: "保存",
           id: 0,
         },
         {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,8 +2,8 @@
   <div class="page">
     <div class="page-wrapper">
       <div class="home-header">
-        <SearchForm :searchWord="searchWord" @change-value="changeSearchWord" />
-        <!-- {{searchList}} -->
+        <SelectBox :value="searchTypeId" :data="searchTypeList" @change-value="changeSearchType" />
+        <SearchForm :searchWord="searchWord" :formData="searchTypeList[searchTypeId]" @change-value="changeSearchWord" @search-mixer="searchMixer" />
       </div>
     </div>
     <div class="home-content">
@@ -19,43 +19,57 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-import TextField from "@/components/atoms/TextField.vue";
-import CommonButton from "@/components/atoms/CommonButton.vue";
+import SelectBox from "@/components/atoms/SelectBox.vue";
 import SearchForm from "@/components/molecules/SearchForm.vue";
 import HomeTile, { ImixerData } from "@/components/organisms/HomeTile.vue";
 
+import { HOME_SEARCH_TYPE_LIST, IselectBoxList } from "@/mixins/selectBoxList";
+
 type DataType = {
-  searchWord: string;
-  showMixersDetail: Boolean;
+  searchTypeList: IselectBoxList[];
 };
 
 export default defineComponent({
   name: "Home",
   components: {
-    TextField,
-    CommonButton,
+    SelectBox,
     SearchForm,
     HomeTile,
   },
   data(): DataType {
     return {
-      searchWord: "", //検索ボックスに入力した文字列
-      showMixersDetail: false,
+      searchTypeList: HOME_SEARCH_TYPE_LIST, //セレクトボックスのデータリスト
     };
   },
   created() {
     (this as any).$store.dispatch("exchange/setHomeTile"); //mix師12人の情報取得
   },
   computed: {
+    searchWord(): string {
+      //検索ボックスに入力した文字列
+      return (this as any).$store.state.common.searchWord;
+    },
+    searchTypeId(): string {
+      //検索モードのID(0~4)
+      return (this as any).$store.state.common.searchTypeId;
+    },
     homeMixerList(): ImixerData[] {
       //ホームに表示するMix師のリスト
       return (this as any).$store.state.exchange.homeMixerList;
     },
   },
   methods: {
-    changeSearchWord(value: string) {
+    changeSearchWord(value: string | number) {
       //検索ワードの変更
-      this.searchWord = value;
+      (this as any).$store.commit("common/setSearchWord", value);
+    },
+    changeSearchType(value: number): void {
+      //検索モードの変更
+      (this as any).$store.dispatch("common/changeSearchType", value);
+    },
+    searchMixer(): void {
+      //検索処理
+      (this as any).$store.dispatch("exchange/searchMixer");
     },
   },
 });

--- a/src/views/Message.vue
+++ b/src/views/Message.vue
@@ -10,7 +10,7 @@
       </div>
       <div class="message-aside-list">
         <UserTab
-          v-for="(data, index) in clientList"
+          v-for="(data, index) in filteredClientList"
           :key="index"
           :data="data"
           :selected="data.uid === selectedUid"
@@ -19,7 +19,7 @@
       </div>
     </div>
     <div class="message-content">
-      <div class="message-content-log" v-if="clientList.length !== 0">
+      <div class="message-content-log" v-if="filteredClientList.length !== 0">
         <MessageItem
           v-for="(item, index) in messageDataList"
           :key="index"
@@ -85,15 +85,26 @@ export default defineComponent({
   watch: {
     selectedUid: async function (newValue: string) {
       await (this as any).$store.dispatch("exchange/stopMessageListener"); //前回までのリスナーを停止
-      if (newValue !== "") { //相手が選択された場合
-        (this as any).$store.dispatch("exchange/startMessageListener", newValue); //今回の相手とのメッセージデータをリスナー
+      if (newValue !== "") {
+        //相手が選択された場合
+        (this as any).$store.dispatch(
+          "exchange/startMessageListener",
+          newValue
+        ); //今回の相手とのメッセージデータをリスナー
       }
     },
   },
   computed: {
-    clientList(): profileDataType[] {
-      //チャット相手のリスト
-      return (this as any).$store.state.exchange.clientList;
+    filteredClientList(): profileDataType[] {
+      //検索後のチャット相手のリスト
+      const clientList = (this as any).$store.state.exchange.clientList; //チャット相手のリスト
+      const word = this.searchWord;
+      const filteredList = clientList.filter((client: profileDataType) => {
+        const result: number = client.name.indexOf(word); //ワードが一致した最初のインデックス
+        return result !== -1;
+      });
+
+      return filteredList;
     },
     selectedUid(): profileDataType[] {
       //チャット相手のユーザーID

--- a/src/views/Message.vue
+++ b/src/views/Message.vue
@@ -79,6 +79,17 @@ export default defineComponent({
     (this as any).$store.commit("exchange/setSelectedUid", ""); //相手未選択状態に
     (this as any).$store.commit("exchange/setMessageList", []); //チャット内容初期化
   },
+  unmounted() {
+    (this as any).$store.dispatch("exchange/stopMessageListener"); //リスナーを停止
+  },
+  watch: {
+    selectedUid: async function (newValue: string) {
+      await (this as any).$store.dispatch("exchange/stopMessageListener"); //前回までのリスナーを停止
+      if (newValue !== "") { //相手が選択された場合
+        (this as any).$store.dispatch("exchange/startMessageListener", newValue); //今回の相手とのメッセージデータをリスナー
+      }
+    },
+  },
   computed: {
     clientList(): profileDataType[] {
       //チャット相手のリスト
@@ -120,7 +131,7 @@ export default defineComponent({
 @import "@/assets/scss/color.scss";
 
 .page {
-  background-color: $-primary-400;
+  background-color: $-primary-300;
   display: grid;
   grid-template-columns: minmax(240px, 1fr) 3fr;
   column-gap: 8px;
@@ -149,13 +160,11 @@ export default defineComponent({
     overflow-y: hidden;
     &-log {
       height: 100%;
-      background: $-primary-400;
       overflow-y: scroll;
     }
     &-nobody {
       height: 100%;
       color: $-primary-800;
-      background: $-primary-400;
       display: flex;
       justify-content: center;
       align-items: center;

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -3,13 +3,13 @@
     <div class="confirm-header">
       <ConfirmHeader />
     </div>
-    <div class="page-details">
-      <div class="icon">
-        <div class="icon-content">
+    <div class="page-contents">
+      <div class="page-contents-left">
+        <div class="icon">
           <UserIcon />
         </div>
       </div>
-      <div class="page-contents" v-if="isShowingSinger">
+      <div class="page-contents-right" v-if="isShowingSinger">
         <div class="profile" v-for="(data, index) in singerList" :key="index">
           <div class="profile-label">{{ data.label }}</div>
           <div class="profile-value">
@@ -17,7 +17,7 @@
           </div>
         </div>
       </div>
-      <div class="page-contents" v-else>
+      <div class="page-contents-right" v-else>
         <div class="profile" v-for="(data, index) in mixerList" :key="index">
           <div class="profile-label">{{ data.label }}</div>
           <div class="profile-value">
@@ -31,13 +31,9 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { RouteLocationNormalized } from "vue-router";
 
 import UserIcon from "@/components/atoms/UserIcon.vue";
 import CommonButtonWhite from "@/components/atoms/CommonButtonWhite.vue";
-import WhiteButtonsSet, {
-  ButtonsSetType as IbuttonsList,
-} from "@/components/molecules/WhiteButtonsSet.vue";
 import ConfirmHeader from "@/components/layouts/ConfirmHeader.vue";
 
 type IprofileData = {
@@ -49,7 +45,6 @@ type IprofileData = {
 };
 
 type DataType = {
-  whiteButtonsList: IbuttonsList[];
   singerList: IprofileData[];
   mixerList: IprofileData[];
   backButtonLabel: string;
@@ -59,7 +54,6 @@ export default defineComponent({
   name: "Profile",
   components: {
     CommonButtonWhite,
-    WhiteButtonsSet,
     UserIcon,
     ConfirmHeader,
   },
@@ -74,7 +68,7 @@ export default defineComponent({
         },
         {
           id: 1,
-          keyName: "detail",
+          keyName: "content",
           label: "自己紹介",
           value: "",
         },
@@ -123,16 +117,6 @@ export default defineComponent({
           value: 0,
         },
       ],
-      whiteButtonsList: [
-        {
-          label: "依頼する",
-          id: 0,
-        },
-        {
-          label: "キャンセル",
-          id: 1,
-        },
-      ],
       backButtonLabel: "戻る",
     };
   },
@@ -163,6 +147,12 @@ export default defineComponent({
         for (let i in this.mixerList) {
           const keyName: string = this.mixerList[i].keyName;
           this.mixerList[i].value = clientProfile[keyName]; //情報をリストのvalueキーに代入
+
+          if (keyName === "fee") {
+            this.mixerList[i].value = this.mixerList[i].value + " 円"; //料金の最後に"円"追加
+          } else if (keyName === "deadline") {
+            this.mixerList[i].value = this.mixerList[i].value + " 日以内"; //期限の最後に"日以内"追加
+          }
         }
       }
     },
@@ -173,7 +163,8 @@ export default defineComponent({
     clickButton(id: number): void {
       //idで処理分岐
       if (id === 0 && this.isSinger) {
-        const clientProfile = (this as any).$store.state.exchange.clientProfileData; //閲覧中のプロフィール情報
+        const clientProfile = (this as any).$store.state.exchange
+          .clientProfileData; //閲覧中のプロフィール情報
         (this as any).$store.dispatch("exchange/startMessage", clientProfile); //チャット相手に登録する処理
         (this as any).$router.push("/message"); //ユーザーが歌い手ならメッセージ画面へ
       } else if (id === 0) {
@@ -191,52 +182,93 @@ export default defineComponent({
 
 .page {
   background-color: $-primary-300;
-  overflow-y: scroll;
-  &-details {
-    display: grid;
-    grid-template-columns: 1fr 1.5fr;
+  &-contents {
+    width: 100%;
+    max-width: 1020px;
+    height: calc(100% - 50px);
+    display: flex;
+    margin: 0 auto;
+    padding: 24px;
     overflow-y: scroll;
-  }
-}
 
-.icon {
-  margin: 10px 0px 10px 10px;
-  &-content {
-    width: 120px;
-    height: 120px;
-    border-radius: 50%;
-    margin-left: 500px; //アイコン左寄せ
-    background-color: $-primary-500;
-  }
-}
+    &-left {
+      width: 40%;
+      display: flex;
+      justify-content: flex-end;
+      padding-right: 10%;
 
-.profile {
-  margin: 20px 100px 20px 0px;
-  &-label {
-    font-size: 20px;
-    padding: 0px 12px;
-  }
-  &-value {
-    font-size: 24px;
-    height: auto;
-    color: $-primary-800;
-    padding-left: 24px;
-  }
-}
+      .icon {
+        width: 120px;
+        height: 120px;
+      }
+    }
 
-@media screen and (max-width: 768px) {
-  //スマホ用の描写
-  .icon {
-    &-content {
-      margin-left: 50px;
+    &-right {
+      flex: 1;
+
+      .profile {
+        &-label {
+          font-size: 20px;
+          text-decoration: underline;
+        }
+        &-value {
+          font-size: 26px;
+          height: auto;
+          color: $-primary-800;
+          padding: 20px 12px;
+        }
+      }
     }
   }
 }
-@media screen and (max-width: 1020px) and (min-width: 768px) {
+
+@media screen and (max-width: 380px) {
+  //スマホ用の描写
+  .page-contents {
+    padding: 24px 12px;
+
+    &-left {
+      width: 100px;
+      justify-content: center;
+      padding-right: 0px;
+      flex: left;
+
+      .icon {
+        width: 80px;
+        height: 80px;
+      }
+    }
+
+    &-right {
+      .profile {
+        &-value {
+          padding-right: 0px !important;
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 600px) and (min-width: 380px) {
   //タブレット用の描写
-  .icon {
-    &-content {
-      margin-left: 200px;
+  .page-contents {
+    &-left {
+      width: 34%;
+      justify-content: center;
+      padding-right: 0px;
+
+      .icon {
+        width: 100px;
+        height: 100px;
+      }
+    }
+
+    &-right {
+      .profile {
+        &-value {
+          padding-right: 0px !important;
+        }
+      }
     }
   }
 }

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -45,7 +45,7 @@ type IprofileData = {
   id: number;
   keyName: string;
   label: string;
-  value: string;
+  value: string | number;
 };
 
 type DataType = {
@@ -53,7 +53,6 @@ type DataType = {
   singerList: IprofileData[];
   mixerList: IprofileData[];
   backButtonLabel: string;
-  prevRoute: RouteLocationNormalized | undefined;
 };
 
 export default defineComponent({
@@ -115,13 +114,13 @@ export default defineComponent({
           id: 3,
           keyName: "fee",
           label: "料金",
-          value: "",
+          value: 0,
         },
         {
           id: 4,
           keyName: "deadline",
           label: "納期",
-          value: "",
+          value: 0,
         },
       ],
       whiteButtonsList: [
@@ -135,8 +134,6 @@ export default defineComponent({
         },
       ],
       backButtonLabel: "戻る",
-
-      prevRoute: undefined, //前回のルート情報(初期はundefined)
     };
   },
   created() {


### PR DESCRIPTION
開いている相手とのメッセージデータのリスナーでリアルタイムに更新
新規登録後、空の項目があるなら編集画面から移動できない